### PR TITLE
latched /map topic for running mapsaver async

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The generated map is published on the `/map` ros topic.
 You can use the `map_saver` node from the `map_server` package inside ros navigation to save your generated map to a .pgm and .yaml file. To do so, start the node before calling the `/gazebo_2Dmap_plugin/generate_map` ros service:
 
 ```
-rosrun map_server map_saver -f <mapname>
+rosrun map_server map_saver -f <mapname> /map:=/map2d
 ```
 The map is saved once you call the map generation service.
 

--- a/README.md
+++ b/README.md
@@ -22,14 +22,14 @@ To generate the map, call the `/gazebo_2Dmap_plugin/generate_map` ros service:
 rosservice call /gazebo_2Dmap_plugin/generate_map
 ```
 
-The generated map is published on the `/map` ros topic. 
+The generated map is published on the `/map2d` ros topic. 
 
-You can use the `map_saver` node from the `map_server` package inside ros navigation to save your generated map to a .pgm and .yaml file. To do so, start the node before calling the `/gazebo_2Dmap_plugin/generate_map` ros service:
+You can use the `map_saver` node from the `map_server` package inside ros navigation to save your generated map to a .pgm and .yaml file:
 
 ```
 rosrun map_server map_saver -f <mapname> /map:=/map2d
 ```
-The map is saved once you call the map generation service.
+The last map generated with the ```/gazebo_2Dmap_plugin/generate_map``` call is saved.
 
 ## Hints
 

--- a/src/gazebo_2Dmap_plugin.cpp
+++ b/src/gazebo_2Dmap_plugin.cpp
@@ -36,7 +36,7 @@ void OccupancyMapFromWorld::Load(physics::WorldPtr _parent,
 
   world_ = _parent;
 
-  map_pub_ = nh_.advertise<nav_msgs::OccupancyGrid>("map", 1);
+  map_pub_ = nh_.advertise<nav_msgs::OccupancyGrid>("map2d", 1, true);
   map_service_ = nh_.advertiseService(
         "gazebo_2Dmap_plugin/generate_map", &OccupancyMapFromWorld::ServiceCallback, this);
 


### PR DESCRIPTION
Adding latched map topic so mapsaver can run asynchronously after the rosservice. Changing the README.md to remap /map to /map2d latched topic accordingly.