### PR TITLE
Gazebo9 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ To include the plugin, add the following line in between the `<world> </world>` 
     <map_height>0.3</map_height>         <!-- in meters, optional, default 0.3 -->
     <map_size_x>10</map_size_x>          <!-- in meters, optional, default 10 -->
     <map_size_y>10</map_size_y>          <!-- in meters, optional, default 10 -->
+    <init_robot_x>0</init_robot_x>          <!-- x coordinate in meters, optional, default 0 -->
+    <init_robot_y>0</init_robot_y>          <!-- y coordinate in meters, optional, default 0 -->
 </plugin>
 ```
 

--- a/include/common.h
+++ b/include/common.h
@@ -22,9 +22,12 @@
 #ifndef ROTORS_GAZEBO_PLUGINS_COMMON_H_
 #define ROTORS_GAZEBO_PLUGINS_COMMON_H_
 
+#define GAZEBO_9 (GAZEBO_MAJOR_VERSION >= 9)
+#define GAZEBO_7 (GAZEBO_MAJOR_VERSION == 7)
+
 #include <Eigen/Dense>
-#include <gazebo-7/gazebo/gazebo.hh>
-//#include <gazebo/gazebo.hh>
+// #include <gazebo-7/gazebo/gazebo.hh>
+#include <gazebo/gazebo.hh>
 
 namespace gazebo {
 

--- a/include/common.h
+++ b/include/common.h
@@ -22,9 +22,6 @@
 #ifndef ROTORS_GAZEBO_PLUGINS_COMMON_H_
 #define ROTORS_GAZEBO_PLUGINS_COMMON_H_
 
-#define GAZEBO_9 (GAZEBO_MAJOR_VERSION >= 9)
-#define GAZEBO_7 (GAZEBO_MAJOR_VERSION == 7)
-
 #include <Eigen/Dense>
 // #include <gazebo-7/gazebo/gazebo.hh>
 #include <gazebo/gazebo.hh>

--- a/include/gazebo_2Dmap_plugin.h
+++ b/include/gazebo_2Dmap_plugin.h
@@ -38,6 +38,14 @@
 
 namespace gazebo {
 
+#if GAZEBO_MAJOR_VERSION >= 9
+  typedef ignition::math::Vector3d vector3d;
+  auto GetPhysicsPtr = std::mem_fn(&gazebo::physics::World::Physics);
+#else
+  typedef math::Vector3 vector3d;
+  auto GetPhysicsPtr = std::mem_fn(&gazebo::physics::World::GetPhysicsEngine);
+#endif
+
 /// \brief    Octomap plugin for Gazebo.
 /// \details  This plugin is dependent on ROS, and is not built if NO_ROS=TRUE is provided to
 ///           CMakeLists.txt. The PX4/Firmware build does not build this file.
@@ -59,8 +67,9 @@ class OccupancyMapFromWorld : public WorldPlugin {
   /// \param[in] _sdf SDF element that describes the plugin.
   void Load(physics::WorldPtr _parent, sdf::ElementPtr _sdf);
 
-  bool worldCellIntersection(const math::Vector3& cell_center, const double cell_length,
-                             gazebo::physics::RayShapePtr ray);
+  bool worldCellIntersection(const vector3d& cell_center, const double cell_length,
+                              gazebo::physics::RayShapePtr ray);
+  
 
 //  void FloodFill(const math::Vector3& seed_point,
 //                 const math::Vector3& bounding_box_origin,

--- a/include/gazebo_2Dmap_plugin.h
+++ b/include/gazebo_2Dmap_plugin.h
@@ -109,6 +109,8 @@ class OccupancyMapFromWorld : public WorldPlugin {
   double map_height_;
   double map_size_x_;
   double map_size_y_;
+  double init_robot_x_;
+  double init_robot_y_;
 };
 
 } // namespace gazebo

--- a/src/gazebo_2Dmap_plugin.cpp
+++ b/src/gazebo_2Dmap_plugin.cpp
@@ -50,6 +50,16 @@ void OccupancyMapFromWorld::Load(physics::WorldPtr _parent,
   if(_sdf->HasElement("map_z"))
     map_height_ = _sdf->GetElement("map_z")->Get<double>();
 
+  init_robot_x_ = 0.0;
+
+  if(_sdf->HasElement("init_robot_x"))
+    init_robot_x_ = _sdf->GetElement("init_robot_x")->Get<double>();
+
+  init_robot_y_ = 0.0;
+
+  if(_sdf->HasElement("init_robot_y"))
+    init_robot_y_ = _sdf->GetElement("init_robot_y")->Get<double>();
+
   map_size_x_ = 10.0;
 
   if(_sdf->HasElement("map_size_x"))
@@ -319,8 +329,8 @@ void OccupancyMapFromWorld::CreateOccupancyMap()
   std::cout << "Starting wavefront expansion for mapping" << std::endl;
 
   //identify free space by spreading out from initial robot cell
-  double robot_x = 0;
-  double robot_y = 0;
+  double robot_x = init_robot_x_;
+  double robot_y = init_robot_y_;
 
   //find initial robot cell
   unsigned int cell_x, cell_y, map_index;

--- a/src/gazebo_2Dmap_plugin.cpp
+++ b/src/gazebo_2Dmap_plugin.cpp
@@ -22,7 +22,7 @@
 
 #include <gazebo/common/Time.hh>
 #include <gazebo/common/CommonTypes.hh>
-#include <gazebo/math/Vector3.hh>
+
 
 namespace gazebo {
 
@@ -30,9 +30,9 @@ OccupancyMapFromWorld::~OccupancyMapFromWorld() {}
 
 void OccupancyMapFromWorld::Load(physics::WorldPtr _parent,
                                  sdf::ElementPtr _sdf) {
-  if (kPrintOnPluginLoad) {
-    gzdbg << __FUNCTION__ << "() called." << std::endl;
-  }
+  // if (kPrintOnPluginLoad) {
+  //   gzdbg << __FUNCTION__ << "() called." << std::endl;
+  // }
 
   world_ = _parent;
 
@@ -172,9 +172,11 @@ bool OccupancyMapFromWorld::ServiceCallback(std_srvs::Empty::Request& req,
   return true;
 }
 
-bool OccupancyMapFromWorld::worldCellIntersection(const math::Vector3& cell_center,
-                                                  const double cell_length,
-                                                  gazebo::physics::RayShapePtr ray)
+
+bool OccupancyMapFromWorld::worldCellIntersection(const vector3d& cell_center,
+                                                const double cell_length,
+                                                gazebo::physics::RayShapePtr ray)
+
 {
   //check for collisions with rays surrounding the cell
   //    ---
@@ -195,21 +197,29 @@ bool OccupancyMapFromWorld::worldCellIntersection(const math::Vector3& cell_cent
 
     for(int i=-1; i<2; i+=2)
     {
-      double start_x = cell_center.x + i * side_length/2;
-      double start_y = cell_center.y - i * side_length/2;
+#if GAZEBO_MAJOR_VERSION >= 9
+      double start_x = cell_center.X() + i * side_length/2;
+      double start_y = cell_center.Y() - i * side_length/2;
+
+      for(int j=-1; j<2; j+=2)
+      {
+        double end_x = cell_center.X() + j * side_length/2;
+        double end_y = cell_center.Y() + j * side_length/2;
+
+        ray->SetPoints(vector3d(start_x, start_y, cell_center.Z()),
+               vector3d(end_x, end_y, cell_center.Z()));
+#else
+        double start_x = cell_center.x + i * side_length/2;
+        double start_y = cell_center.y - i * side_length/2;
 
       for(int j=-1; j<2; j+=2)
       {
         double end_x = cell_center.x + j * side_length/2;
         double end_y = cell_center.y + j * side_length/2;
 
-        //      std::cout << "start_x" << start_x << std::endl;
-        //      std::cout << "start_y" << start_y << std::endl;
-        //      std::cout << "end_x" << end_x << std::endl;
-        //      std::cout << "end_y" << end_y << std::endl;
-
-        ray->SetPoints(math::Vector3(start_x, start_y, cell_center.z),
-                       math::Vector3(end_x, end_y, cell_center.z));
+        ray->SetPoints(vector3d(start_x, start_y, cell_center.z),
+                       vector3d(end_x, end_y, cell_center.z));
+#endif
         ray->GetIntersection(dist, entity_name);
 
         if(!entity_name.empty())
@@ -274,7 +284,7 @@ bool OccupancyMapFromWorld::index2cell(int index, unsigned int cell_size_x,
 void OccupancyMapFromWorld::CreateOccupancyMap()
 {
   //TODO map origin different from (0,0)
-  math::Vector3 map_origin(0,0,map_height_);
+  vector3d map_origin(0,0,map_height_);
 
   unsigned int cells_size_x = map_size_x_ / map_resolution_;
   unsigned int cells_size_y = map_size_y_ / map_resolution_;
@@ -289,12 +299,18 @@ void OccupancyMapFromWorld::CreateOccupancyMap()
   occupancy_map_->info.resolution = map_resolution_;
   occupancy_map_->info.width = cells_size_x;
   occupancy_map_->info.height = cells_size_y;
+#if GAZEBO_MAJOR_VERSION >= 9
+  occupancy_map_->info.origin.position.x = map_origin.X() - map_size_x_ / 2;
+  occupancy_map_->info.origin.position.y = map_origin.Y() - map_size_y_ / 2;
+  occupancy_map_->info.origin.position.z = map_origin.Z();
+#else
   occupancy_map_->info.origin.position.x = map_origin.x - map_size_x_ / 2;
   occupancy_map_->info.origin.position.y = map_origin.y - map_size_y_ / 2;
   occupancy_map_->info.origin.position.z = map_origin.z;
+#endif
   occupancy_map_->info.origin.orientation.w = 1;
 
-  gazebo::physics::PhysicsEnginePtr engine = world_->GetPhysicsEngine();
+  gazebo::physics::PhysicsEnginePtr engine = GetPhysicsPtr(world_);
   engine->InitForThread();
   gazebo::physics::RayShapePtr ray =
       boost::dynamic_pointer_cast<gazebo::physics::RayShape>(
@@ -353,7 +369,7 @@ void OccupancyMapFromWorld::CreateOccupancyMap()
             cell2world(cell_x + i, cell_y + j, map_size_x_, map_size_y_, map_resolution_,
                        world_x, world_y);
 
-            bool cell_occupied = worldCellIntersection(math::Vector3(world_x, world_y, map_height_),
+            bool cell_occupied = worldCellIntersection(vector3d(world_x, world_y, map_height_),
                                                        map_resolution_, ray);
 
             if(cell_occupied)


### PR DESCRIPTION
# Description
- Adds support for Gazebo9 (https://github.com/marinaKollmitz/gazebo_ros_2Dmap_plugin/issues/9)
- Tracks changes from https://github.com/marinaKollmitz/gazebo_ros_2Dmap_plugin/issues/7 

# Tests
- Plugin compiles gracefully in Gazebo7 and Gazebo9.
- Tested on the following Gazebo worlds:
   - willowgarage.world
   - https://github.com/aws-robotics/aws-robomaker-bookstore-world
   - https://github.com/aws-robotics/aws-robomaker-small-house-world
   - https://github.com/aws-robotics/aws-robomaker-small-warehouse-world
  - Map generation works as expected in Gazebo7 and 9.
  - No visual discrepancy in the maps generated when used in gazebo7 and gazebo9. 

