### PR TITLE
add costmap_2d to CMakeList packages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ find_package(catkin REQUIRED COMPONENTS
   gazebo_ros
   gazebo_ros_control
   gazebo_plugins
+  costmap_2d
   joint_state_publisher
   kdl_parser
   robot_state_publisher

--- a/package.xml
+++ b/package.xml
@@ -19,6 +19,7 @@
   <build_depend>rospy</build_depend>
   <build_depend>tf</build_depend>
   <build_depend>xacro</build_depend>
+  <build_depend>costmap_2d</build_depend>
   <run_depend>gazebo_msgs</run_depend>
   <run_depend>gazebo_ros</run_depend>
   <run_depend>gazebo_ros_control</run_depend>
@@ -29,5 +30,6 @@
   <run_depend>rospy</run_depend>
   <run_depend>tf</run_depend>
   <run_depend>xacro</run_depend>
+  <run_depend>costmap_2d</run_depend>
 
 </package>


### PR DESCRIPTION
There is an error while compiling code using catkin_make
this change will fix it
```
catkin_ws/src/gazebo_ros_2Dmap_plugin/include/gazebo_2Dmap_plugin.h:36:10: fatal error: costmap_2d/costmap_2d_ros.h: No such file or directory
   36 | #include <costmap_2d/costmap_2d_ros.h>
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
```