### PR TITLE
use c++ 17 to build instead of c++ 11 to fix errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ find_package(catkin REQUIRED COMPONENTS
   xacro
 )
 
-add_definitions(-std=c++11)
+add_definitions(-std=c++17)
 
 find_package(gazebo REQUIRED)
 link_directories(${GAZEBO_LIBRARY_DIRS})


### PR DESCRIPTION
fixes build errors like:

```
error: ‘chrono_literals’ is not a namespace-name
 1059 |       using namespace std::chrono_literals;

error: ‘optional’ in namespace ‘std’ does not name a template type
  133 |       public: std::optional<Vector3<T>> Intersection
```

tested under Ubuntu 20.04 with ROS1 noetic distro